### PR TITLE
feat(renovate): add internalChecksFilter strict

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:recommended"
   ],
+  "internalChecksFilter": "strict",
   "automerge": false,
   "respectLatest": true,
   "ignoreTests": true,


### PR DESCRIPTION
Adds `"internalChecksFilter": "strict"` to the Renovate config. This ensures Renovate enforces its internal stability checks (e.g. `minimumReleaseAge`) before proceeding with updates, preventing premature merges of newly published packages.